### PR TITLE
Fix for BS 1.1.0

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -123,8 +123,8 @@ const ui = (() => {
 			cover.setAttribute("src", `data:image/png;base64,${data.songCover}`);
 
 			title.innerText = data.songName;
-			subtitle.innerText = data.songSubName;
-			artist.innerText = data.songAuthorName;
+			subtitle.innerText = data.songAuthorName;
+			artist.innerText = data.levelAuthorName;
 
 			difficulty.innerText = data.difficulty;
 			bpm.innerText = `${format(data.songBPM)} BPM`;


### PR DESCRIPTION
New song format in 1.1.0 uses songAuthorName (music artist) and levelAuthorName (mapper) instead of songSubName.