### PR TITLE
Added 'bsr' and 'no-performance' to modifiers options.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,30 @@
 MIT License
 
+Copyright (c) 2020 rynan4818 [リュナン](Twitter @rynan4818)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The major design pattern of this plugin was abstracted from Reselim's (Unnamed) Beat Saber Overlay, which is subject to the same license.
+Here is the original copyright notice for (Unnamed) Beat Saber Overlay:
+
+MIT License
+
 Copyright (c) 2018 Reselim
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Beat SaberをOBS等で配信や録画する時に譜面情報をオーバーレ�
 1. [Beat Saber HTTP Status](https://github.com/opl-/beatsaber-http-status) か、拙作の[Beat Saber HTTP Status +Database](https://github.com/rynan4818/beatsaber-http-status-db)をダウンロードしてインストールします。
 
 - HTTP StatusはRelease v1.11.1以降のバージョンを使用して下さい。(6/28現在 ModAssistantで対応済み)
-- HTTP Status +DatabaseはRelease v2020/06/08以降を使用して下さい。
+- [bs-movie-cut(プレイ動画カットツール）](https://github.com/rynan4818/bs-movie-cut)を使用する場合は、HTTP Status +DatabaseはRelease v2020/06/08以降を使用して下さい。
 
 2. [リリースページ](https://github.com/rynan4818/beat-saber-overlay-noscore/releases)から最新のリリースをダウンロードします。
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=t
 - `top`
 	* オーバーレイの表示を上部に配置し、レイアウトを垂直方向に反転します。
 - `rtl`
-	* オーバーレイを右に移動し、右揃えのレイアウトにします。
+	* オーバーレイを右に移動し、右揃えのレイアウトにします。	`!`と`.`の表示に問題があります。（下記参照)
 - `scale`
 	* 1080p(1920x1080)の画面で使用するために、オーバーレイを1.5倍にスケーリングします。
 - `test`
@@ -53,6 +53,20 @@ file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=t
 	* bsrの検索・表示をします。（今回追加）
 - `no-performance`
 	* スコア表示を消します。　 （今回追加）
+
+### `rtl`の表示修正
+
+上記`rtl`オプションを使用すると、下記画像の様に`!`や`.`の表示位置がおかしくなる問題があります。
+
+![image](https://github.com/rynan4818/rynan4818.github.io/blob/master/beatsaber-overlay-rtl2.png?raw=true)
+
+この問題を修正するため、`rtl`オプションの代わりに、`index_rtl.html`を追加しました。
+`index.html`の代わりに`index_rtl.html`に変更して使用してください。
+デフォルトで右側表示になります。`rtl`オプション以外はそのまま使用可能です。
+
+```
+file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index_rtl.html?modifiers=top,bsr
+```
 
 ### bsrの表示位置や文字サイズを変更したい場合
 

--- a/README.md
+++ b/README.md
@@ -39,5 +39,9 @@ Multiple modifiers can be seperated with commas.
 	* Moves the overlay to the right and uses right-to-left text
 - `scale`
 	* Scales the overlay by 1.5x, for use on 1080p canvases
+- `bsr`
+	* Show beatsaver's map key
+- `no-performance`
+	* No performance data is displayed
 - `test`
 	* Makes the background black, for testing purposes

--- a/README.md
+++ b/README.md
@@ -63,4 +63,6 @@ file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=t
 ![image](https://rynan4818.github.io/beatsaber-overlay-css.png)
 
 ## 正式公開について
-上記改造版は本家に[プルリクエスト](https://github.com/Reselim/beat-saber-overlay/pull/15)依頼済みです。[2020/6/6]
+~~上記改造版は本家に[プルリクエスト](https://github.com/Reselim/beat-saber-overlay/pull/15)依頼済みです。[2020/6/6]~~
+
+オリジナルのリポジトリがアーカイブされてしまったので、このままここに置いておきます。

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Beat Saber Overlay bsr,no_performance オプション追加版
+# Beat Saber Overlay bsr,no-performance オプション追加版
 
 これは、Reselim氏が製作した[Beat Saber Overlay](https://github.com/Reselim/beat-saber-overlay)に、bsr表示(bsr)とスコア表示無し(no-performance)のオプションを追加したバージョンです。
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Beat Saber Overlay bsr,no_performance オプション追加版
 
-これは、Reselim氏が製作した[Beat Saber Overlay](https://github.com/Reselim/beat-saber-overlay)に、bsr表示(bsr)とスコア表示無し(no_performance)のオプションを追加したバージョンです。
+これは、Reselim氏が製作した[Beat Saber Overlay](https://github.com/Reselim/beat-saber-overlay)に、bsr表示(bsr)とスコア表示無し(no-performance)のオプションを追加したバージョンです。
 
 Beat SaberをOBS等で配信や録画する時に譜面情報をオーバーレイ表示します。
 
@@ -51,7 +51,7 @@ file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=t
 	* テストのために背景を黒にします。
 - `bsr`
 	* bsrの検索・表示をします。（今回追加）
-- `no_performance`
+- `no-performance`
 	* スコア表示を消します。　 （今回追加）
 
 ### bsrの表示位置や文字サイズを変更したい場合

--- a/README.md
+++ b/README.md
@@ -15,26 +15,26 @@ Beat SaberをOBS等で配信や録画する時に譜面情報をオーバーレ�
 
 2. [リリースページ](https://github.com/rynan4818/beat-saber-overlay-noscore/releases)から最新のリリースをダウンロードします。
 
-3. zipを適当なフォルダに解凍します。例: C:\TOOL\beat-saber-overlay-bsr_no-performance_add\
+3. zipを適当なフォルダに解凍します。例: C:\TOOL\beat-saber-overlay-bsr_no-performance\
 
 4. OBSのソースにブラウザを追加します。
 
 ![image](https://rynan4818.github.io/beatsaber-overlay-noscore-obs-setting1.png)
 
-5. zipを解凍したフォルダ名に合わせてプロパティのURLに `file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=bsr` の様に設定します。また、画面サイズと同じ幅と高さに設定します。 (1280x720 など)
+5. zipを解凍したフォルダ名に合わせてプロパティのURLに `file:///C:/TOOL/beat-saber-overlay-bsr_no-performance/index.html?modifiers=bsr` の様に設定します。また、画面サイズと同じ幅と高さに設定します。 (1280x720 など)
 
 ![image](https://rynan4818.github.io/beatsaber-overlay-bsr-obs-setting.png)
 
 ローカルファイルだと、オプション設定が出来ないのでURL表記で入力する必要があります。解凍したファイルのindex.htmlをブラウザで開いて、アドレス欄からコピー＆ペーストするのが楽です。
 
-6. (オプション) 1080p(1920x1080)の画面サイズの場合,オーバレイ表示を1.5倍に拡大する `scale` 修飾子を使用して下さい。例: `file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=bsr,scale`
+6. (オプション) 1080p(1920x1080)の画面サイズの場合,オーバレイ表示を1.5倍に拡大する `scale` 修飾子を使用して下さい。例: `file:///C:/TOOL/beat-saber-overlay-bsr_no-performance/index.html?modifiers=bsr,scale`
 
 ## オプション
 
 次の様なオプションがURLに設定可能です。
 
 ```
-file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=top,bsr
+file:///C:/TOOL/beat-saber-overlay-bsr_no-performance/index.html?modifiers=top,bsr
 ```
 
 ### `modifiers`
@@ -65,7 +65,7 @@ file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=t
 デフォルトで右側表示になります。`rtl`オプション以外はそのまま使用可能です。
 
 ```
-file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index_rtl.html?modifiers=top,bsr
+file:///C:/TOOL/beat-saber-overlay-bsr_no-performance/index_rtl.html?modifiers=top,bsr
 ```
 
 ### bsrの表示位置や文字サイズを変更したい場合

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ file:///C:/TOOL/beat-saber-overlay-bsr_no-performance/index.html?modifiers=top,b
 	* bsrの検索・表示をします。（今回追加）
 - `no-performance`
 	* スコア表示を消します。　 （今回追加）
+- `no-hidden`
+	* 終了時に表示を消しません。（今回追加）
 
 ### `rtl`の表示修正
 
@@ -67,8 +69,51 @@ file:///C:/TOOL/beat-saber-overlay-bsr_no-performance/index.html?modifiers=top,b
 ```
 file:///C:/TOOL/beat-saber-overlay-bsr_no-performance/index_rtl.html?modifiers=top,bsr
 ```
+## BSDP-Overlayライクなオーバーレイ
+[DataPuller](https://github.com/kOFReadie/BSDataPuller)の[BSDP-Overlay](https://github.com/kOFReadie/BSDP-Overlay)ライクなオーバーレイ表示用のHTMLとCSSを作成しました。
 
-### bsrの表示位置や文字サイズを変更したい場合
+以下からダウンロードして、本オーバーレイのインストールフォルダに上書きで追加インストールすることで使用可能です。
+
+[bsdp-like-overlay](https://github.com/rynan4818/bsdp-like-overlay)
+
+## オーバーレイの改造
+スクリプトではHTMLタグの以下のidに対して、プレイに合わせた書き換え動作をします。idは起動時にチェックし、HTML内にidが存在しない場合は書き換えないため、HTMLやCSSを改造して好きなレイアウトや表示項目にすることが出来ます。
+
+参考に、精度・スコア・曲名・bsr表示だけにしたシンプルな表示のhtmlを用意しました。
+```
+file:///C:/TOOL/beat-saber-overlay-bsr_no-performance/simple.html?modifiers=bsr
+```
+
+| id | 動作 |
+----|----
+| overlay | プレイ開始時にclass="hidden"を付与、終了時に削除します。 |
+| rank | スコアのランク(SS,S,A,B,C・・・)に書き換えます。 |
+| percentage | スコアの精度(xx.x%)に書き換えます。 |
+| combo | コンボ数に書き換えます。 |
+| score | スコアに書き換えます。 |
+| progress | 曲のプレイ時間の円グラフを表示します。 |
+| performance | no-performance オプション時に、このタグの内容を削除します。 |
+| image | src属性に曲のカバー画像をセットします。 |
+| title | 曲のタイトルに書き換えます。 |
+| subtitle | 曲のサブタイトル情報に書き換えます。 |
+| artist | 曲のアーティスト情報に書き換えます。 |
+| difficulty | 難易度情報に書き換えます。 |
+| bpm | 曲のBPM情報に書き換えます。 |
+| njs | NJS情報に書き換えます。 |
+| njs_text | NJSの項目名を起動時に保持し、NJS表示が出来ない場合は表示を消します。 |
+| bsr | BeatSaverのkey(bsr)情報に書き換えます。 |
+| bsr_text | bsrの項目名を起動時に保持し、NJS表示が出来ない場合は表示を消します。 |
+| mapper | 譜面の作者名を表示します。 |
+| mapper_header | 譜面の作者名のヘッダー表示を起動時に保持し、表示出来ない場合は消します。 |
+| mapper_footer | 譜面の作者名のフッター表示を起動時に保持し、表示出来ない場合は消します。 |
+| song_time | プレイ中の曲の再生時間に書き換えます。 |
+| song_length | 曲の長さの時間に書き換えます。 |
+| mod | 適用中のmod(IF,BE,DA,GN,FS,SS,NF,NO,NB,NA)情報に書き換えます。 |
+| miss | ミス数(ノーツミス＋爆弾カット)に書き換えます。 |
+| pre_bsr | 一つ前にプレイした譜面のbsr情報を表示します。 |
+| pre_bsr_text | pre_bsrの項目名を起動時に保持し、NJS表示が出来ない場合は表示を消します。　|
+
+## bsrの表示位置や文字サイズを変更したい場合
 
 表示位置を変更したい場合は`index.html`の以下の部分を修正して下さい。
 ![image](https://rynan4818.github.io/beatsaber-overlay-index-html.png)
@@ -80,3 +125,4 @@ file:///C:/TOOL/beat-saber-overlay-bsr_no-performance/index_rtl.html?modifiers=t
 ~~上記改造版は本家に[プルリクエスト](https://github.com/Reselim/beat-saber-overlay/pull/15)依頼済みです。[2020/6/6]~~
 
 オリジナルのリポジトリがアーカイブされてしまったので、このままここに置いておきます。
+

--- a/README.md
+++ b/README.md
@@ -1,47 +1,66 @@
-# (Unnamed) Beat Saber Overlay
+# Beat Saber Overlay bsr,no_performance オプション追加版
 
-A web-based overlay for Beat Saber
+これは、Reselim氏が製作した[Beat Saber Overlay](https://github.com/Reselim/beat-saber-overlay)に、bsr表示(bsr)とスコア表示無し(no_performance)のオプションを追加したバージョンです。
 
-![preview](https://i.imgur.com/fOg4TUp.png)
+Beat SaberをOBS等で配信や録画する時に譜面情報をオーバーレイ表示します。
 
-## Installation (OBS)
+![preview](https://rynan4818.github.io/beatsaber-overlay-bsr-image.png)
 
-1. Download and install the [BeatSaberHTTPStatus plugin](https://github.com/opl-/beatsaber-http-status/releases)
-2. Create a Browser source
+## インストール方法 (OBS)
 
-![image](https://i.imgur.com/WyTjdtd.png)
+1. [Beat Saber HTTP Status](https://github.com/opl-/beatsaber-http-status) か、拙作の[Beat Saber HTTP Status +Database](https://github.com/rynan4818/beatsaber-http-status-db)をダウンロードしてインストールします。
 
-3. Set the URL as `http://reselim.github.io/overlay/` (HTTP, not HTTPS!) and the size equal to your canvas size (1280x720, etc.)
+- HTTP StatusはRelease v1.11.1以降のバージョンを使用して下さい。(6/28現在 ModAssistantで対応済み)
+- HTTP Status +DatabaseはRelease v2020/06/08以降を使用して下さい。
 
-![image](https://imgur.com/KxowYrw.png)
+2. [リリースページ](https://github.com/rynan4818/beat-saber-overlay-noscore/releases)から最新のリリースをダウンロードします。
 
-4. (Optional) For 1080p canvases, add the `scale` modifier (ex. `http://reselim.github.io/overlay/?modifiers=scale`) to scale the overlay by 1.5x
+3. zipを適当なフォルダに解凍します。例: C:\TOOL\beat-saber-overlay-bsr_no-performance_add\
 
-## Options
+4. OBSのソースにブラウザを追加します。
 
-Options are added to the URL query as such:
+![image](https://rynan4818.github.io/beatsaber-overlay-noscore-obs-setting1.png)
+
+5. zipを解凍したフォルダ名に合わせてプロパティのURLに `file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=bsr` の様に設定します。また、画面サイズと同じ幅と高さに設定します。 (1280x720 など)
+
+![image](https://rynan4818.github.io/beatsaber-overlay-bsr-obs-setting.png)
+
+ローカルファイルだと、オプション設定が出来ないのでURL表記で入力する必要があります。解凍したファイルのindex.htmlをブラウザで開いて、アドレス欄からコピー＆ペーストするのが楽です。
+
+6. (オプション) 1080p(1920x1080)の画面サイズの場合,オーバレイ表示を1.5倍に拡大する `scale` 修飾子を使用して下さい。例: `file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=bsr,scale`
+
+## オプション
+
+次の様なオプションがURLに設定可能です。
 
 ```
-http://reselim.github.io/overlay/?modifiers=top
+file:///C:/TOOL/beat-saber-overlay-bsr_no-performance_add/index.html?modifiers=top,bsr
 ```
-
-### `ip` and `port`
-
-Listen to events from another IP and/or port.
 
 ### `modifiers`
 
-Multiple modifiers can be seperated with commas.
+複数のオプションは,(カンマ)で区切ることができます。
 
 - `top`
-	* Moves the overlay to the top and reverses the layout vertically
+	* オーバーレイの表示を上部に配置し、レイアウトを垂直方向に反転します。
 - `rtl`
-	* Moves the overlay to the right and uses right-to-left text
+	* オーバーレイを右に移動し、右揃えのレイアウトにします。
 - `scale`
-	* Scales the overlay by 1.5x, for use on 1080p canvases
-- `bsr`
-	* Show beatsaver's map key
-- `no-performance`
-	* No performance data is displayed
+	* 1080p(1920x1080)の画面で使用するために、オーバーレイを1.5倍にスケーリングします。
 - `test`
-	* Makes the background black, for testing purposes
+	* テストのために背景を黒にします。
+- `bsr`
+	* bsrの検索・表示をします。（今回追加）
+- `no_performance`
+	* スコア表示を消します。　 （今回追加）
+
+### bsrの表示位置や文字サイズを変更したい場合
+
+表示位置を変更したい場合は`index.html`の以下の部分を修正して下さい。
+![image](https://rynan4818.github.io/beatsaber-overlay-index-html.png)
+
+文字サイズなどは`style.css`の以下を修正して下さい。
+![image](https://rynan4818.github.io/beatsaber-overlay-css.png)
+
+## 正式公開について
+上記改造版は本家に[プルリクエスト](https://github.com/Reselim/beat-saber-overlay/pull/15)依頼済みです。[2020/6/6]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ file:///C:/TOOL/beat-saber-overlay-bsr_no-performance/simple.html?modifiers=bsr
 
 | id | 動作 |
 ----|----
-| overlay | プレイ開始時にclass="hidden"を付与、終了時に削除します。 |
+| overlay | プレイ開始時にclass="hidden"を削除、終了時に付与します。 |
 | rank | スコアのランク(SS,S,A,B,C・・・)に書き換えます。 |
 | percentage | スコアの精度(xx.x%)に書き換えます。 |
 | combo | コンボ数に書き換えます。 |

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 
 				<div class="performance-group">
 					<span class="text" id="combo">0</span>
-					<span class="subtext">Combo</span>
+					<span class="subtext" id="combo_text">Combo</span>
 				</div>
 				
 				<span id="score">0</span>
@@ -47,7 +47,9 @@
 
 						<span id="artist">Artist</span>
 					</div>
-					
+					<div>
+						<span id="bsr">bsr 0000</span>
+					</div>
 					<div>
 						<span id="difficulty">Easy</span>
 						<span id="bpm">0 BPM</span>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 
 				<div class="performance-group">
 					<span class="text" id="combo">0</span>
-					<span class="subtext" id="combo_text">Combo</span>
+					<span class="subtext">Combo</span>
 				</div>
 				
 				<span id="score">0</span>
@@ -34,7 +34,7 @@
 					</svg>
 
 					<div>
-						<span id="progress-text">0:00</span>
+						<span id="song_time">0:00</span>
 					</div>
 				</div>
 
@@ -45,15 +45,21 @@
 							<span id="subtitle">Subtitle</span>
 						</div>
 
-						<span id="artist">Artist</span>
+						<div id="artist-group">
+							<span id="artist">Artist</span><span id="mapper_header"> [</span><span id="mapper">Mapper</span><span id="mapper_footer">]</span>
+						</div>
 					</div>
-					<div>
-						<span id="bsr">bsr 0000</span>
+					<div id="bsr-group">
+						<span id="bsr_text">bsr </span><span id="bsr">00000</span>
 					</div>
 					<div>
 						<span id="difficulty">Easy</span>
-						<span id="bpm">0 BPM</span>
-						<span id="njs">0 NJS</span>
+						<span id="bpm-group">
+							<span id="bpm">0</span><span id="bpm_text"> BPM</span>
+						</span>
+						<span id="njs-group">
+							<span id="njs">0</span><span id="njs_text"> NJS</span>
+						</span>
 					</div>
 				</div>
 			</div>

--- a/index_rtl.html
+++ b/index_rtl.html
@@ -17,7 +17,7 @@
 				</div>
 
 				<div class="performance-group">
-					<span class="subtext" id="combo_text">Combo</span>
+					<span class="subtext">Combo</span>
 					<span class="text" id="combo">0</span>
 				</div>
 				
@@ -32,14 +32,20 @@
 							<span id="title">Title</span>
 						</div>
 
-						<span id="artist">Artist</span>
+						<div id="artist-group">
+							<span id="artist">Artist</span><span id="mapper_header"> [</span><span id="mapper">Mapper</span><span id="mapper_footer">]</span>
+						</div>
+					</div>
+					<div id="bsr-group">
+						<span id="bsr_text">bsr </span><span id="bsr">00000</span>
 					</div>
 					<div>
-						<span id="bsr">bsr 0000</span>
-					</div>
-					<div>
-						<span id="njs">0 NJS</span>
-						<span id="bpm">0 BPM</span>
+						<span id="njs-group">
+							<span id="njs">0</span><span id="njs_text"> NJS</span>
+						</span>
+						<span id="bpm-group">
+							<span id="bpm">0</span><span id="bpm_text"> BPM</span>
+						</span>
 						<span id="difficulty">Easy</span>
 					</div>
 				</div>
@@ -53,7 +59,7 @@
 					</svg>
 
 					<div>
-						<span id="progress-text">0:00</span>
+						<span id="song_time">0:00</span>
 					</div>
 				</div>
 			</div>

--- a/index_rtl.html
+++ b/index_rtl.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Overlay</title>
+		<link rel="stylesheet" href="style.css">
+		<link rel="stylesheet" href="rtl2.css">
+		<link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700,800" rel="stylesheet"> 
+	</head>
+	
+	<body>
+		<div id="overlay" class="hidden">
+			<div id="performance">
+				<div class="performance-group">
+					<span class="subtext" id="percentage">0%</span>
+					<span class="text" id="rank">E</span>
+				</div>
+
+				<div class="performance-group">
+					<span class="subtext" id="combo_text">Combo</span>
+					<span class="text" id="combo">0</span>
+				</div>
+				
+				<span id="score">0</span>
+			</div>
+
+			<div id="beatmap">
+				<div id="meta">
+					<div id="text">
+						<div id="titles">
+							<span id="subtitle">Subtitle</span>
+							<span id="title">Title</span>
+						</div>
+
+						<span id="artist">Artist</span>
+					</div>
+					<div>
+						<span id="bsr">bsr 0000</span>
+					</div>
+					<div>
+						<span id="njs">0 NJS</span>
+						<span id="bpm">0 BPM</span>
+						<span id="difficulty">Easy</span>
+					</div>
+				</div>
+				<div id="cover">
+					<img id="image">
+					
+					<svg width="90" height="90">
+						<rect width="90" height="90" id="darken"></rect>
+						<circle cx="45" cy="45" r="30" id="remaining"></circle>
+						<circle cx="45" cy="45" r="30" id="progress"></circle>
+					</svg>
+
+					<div>
+						<span id="progress-text">0:00</span>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<script src="./js/options.js"></script>
+		
+		<script src="./js/ui.js"></script>
+		<script src="./js/events.js"></script>
+		<script src="./js/manager.js"></script>
+	</body>
+</html>

--- a/js/events.js
+++ b/js/events.js
@@ -3,14 +3,14 @@ const events = {
 		console.log("Connected to Beat Saber");
 
 		if (data.beatmap && data.performance) {
-			ui.beatmap(data.beatmap, time);
+			ui.beatmap(data.beatmap, time, data.mod);
 			ui.performance(data.performance);
 			ui.show();
 		}
 	},
 
 	songStart(data, time) {
-		ui.beatmap(data.beatmap, time);
+		ui.beatmap(data.beatmap, time, data.mod);
 		ui.performance(data.performance);
 		ui.show();
 	},
@@ -31,6 +31,8 @@ const events = {
 
 	menu() {
 		ui.timer.stop();
-		ui.hide();
+		if (disp_hidden) {
+			ui.hide();
+		}
 	}
 }

--- a/js/options.js
+++ b/js/options.js
@@ -1,6 +1,24 @@
 const query = new URLSearchParams(location.search);
-var performance_display = true;
 var bsr_display = false;
+var disp_hidden = true;
+var pre_bsr_data = null;
+const check_id = ["overlay","rank","percentage","combo","score","progress","performance",
+                  "image","title","subtitle","artist","difficulty","bpm","njs","bsr","bsr_text",
+                  "mapper","mapper_header","mapper_footer","song_time","song_length","mod","miss",
+                  "pre_bsr","pre_bsr_text","njs_text"]
+var html_id = {};
+for (var i = 0, len = check_id.length; i < len; ++i) {
+	if (document.getElementById(check_id[i]) === null) {
+		html_id[check_id[i]] = false;
+	} else {
+		html_id[check_id[i]] = true;
+	}
+}
+if (html_id["mapper_header"]) var mapper_header_org = document.getElementById("mapper_header").textContent;
+if (html_id["mapper_footer"]) var mapper_footer_org = document.getElementById("mapper_footer").textContent;
+if (html_id["bsr_text"])      var bsr_text_org = document.getElementById("bsr_text").textContent;
+if (html_id["pre_bsr_text"])  var pre_bsr_text_org = document.getElementById("pre_bsr_text").textContent;
+if (html_id["njs_text"])      var njs_text_org = document.getElementById("njs_text").textContent;
 
 (() => {
 	const handlers = {
@@ -10,13 +28,21 @@ var bsr_display = false;
 					bsr_display = true;
 					return;
 				}
+				if (modifier === "no-hidden") {
+					disp_hidden = false;
+					return;
+				}
 				if (modifier === "no-performance") {
-					performance_display = false;
-					document.getElementById("rank").innerText = "";
-					document.getElementById("percentage").innerText = "";
-					document.getElementById("score").innerText = "";
-					document.getElementById("combo").innerText = "";
-					document.getElementById("combo_text").innerText = "";
+					if (html_id["performance"]) {
+						var dom_obj = document.getElementById("performance");
+						var dom_obj_parent = dom_obj.parentNode;
+						dom_obj_parent.removeChild(dom_obj);
+					}
+					html_id["rank"] = false;
+					html_id["percentage"] = false;
+					html_id["score"] = false;
+					html_id["combo"] = false;
+					html_id["miss"] = false;
 					return;
 				}
 				var link = document.createElement("link");

--- a/js/options.js
+++ b/js/options.js
@@ -1,9 +1,24 @@
 const query = new URLSearchParams(location.search);
+var performance_display = true;
+var bsr_display = false;
 
 (() => {
 	const handlers = {
 		modifiers(string) {
 			string.split(",").forEach((modifier) => {
+				if (modifier === "bsr") {
+					bsr_display = true;
+					return;
+				}
+				if (modifier === "no-performance") {
+					performance_display = false;
+					document.getElementById("rank").innerText = "";
+					document.getElementById("percentage").innerText = "";
+					document.getElementById("score").innerText = "";
+					document.getElementById("combo").innerText = "";
+					document.getElementById("combo_text").innerText = "";
+					return;
+				}
 				var link = document.createElement("link");
 				
 				link.setAttribute("rel", "stylesheet");

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,21 +1,24 @@
 const ui = (() => {
-	var main = document.getElementById("overlay");
+	if (html_id["overlay"]) var main = document.getElementById("overlay");
+	var now_bsr = null;
 
 	const performance = (() => {
-		var rank = document.getElementById("rank");
-		var percentage = document.getElementById("percentage");
-		var score = document.getElementById("score");
-		var combo = document.getElementById("combo");
+		if (html_id["rank"])       var rank = document.getElementById("rank");
+		if (html_id["percentage"]) var percentage = document.getElementById("percentage");
+		if (html_id["score"])      var score = document.getElementById("score");
+		if (html_id["combo"])      var combo = document.getElementById("combo");
+		if (html_id["miss"])       var miss = document.getElementById("miss");
 
 		function format(number) {
 			return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 		}
 
 		return (data) => {
-			if (performance_display) {
-				score.innerText = format(data.score);
-				combo.innerText = data.combo;
-				rank.innerText = data.rank;
+			if (html_id["score"]) score.innerText = format(data.score);
+			if (html_id["combo"]) combo.innerText = data.combo;
+			if (html_id["rank"])  rank.innerText = data.rank;
+			if (html_id["miss"])  miss.innerText = data.missedNotes + data.hitBombs;
+			if (html_id["percentage"]) {
 				percentage.innerText = (data.currentMaxScore > 0 ? (Math.floor((data.score / data.currentMaxScore) * 1000) / 10) : 0) + "%";
 			}
 		}
@@ -25,13 +28,15 @@ const ui = (() => {
 		const radius = 30;
 		const circumference = radius * Math.PI * 2;
 
-		var bar = document.getElementById("progress");
-		var text = document.getElementById("progress-text");
+		if (html_id["progress"])      var bar = document.getElementById("progress");
+		if (html_id["song_time"])     var song_time = document.getElementById("song_time");
 
 		var active = false;
 
 		var began;
 		var duration;
+		var length_min;
+		var length_sec;
 
 		var display;
 
@@ -54,12 +59,12 @@ const ui = (() => {
 			var progress = Math.floor(delta / 1000);
 			var percentage = Math.min(delta / duration, 1);
 
-			bar.setAttribute("style", `stroke-dashoffset: ${(1 - percentage) * circumference}px`);
+			if (html_id["progress"]) bar.setAttribute("style", `stroke-dashoffset: ${(1 - percentage) * circumference}px`);
 
 			// Minor optimization
 			if (progress != display) {
 				display = progress;
-				text.innerText = format(progress);
+				if (html_id["song_time"]) song_time.innerText = format(progress);
 			}
 		}
 
@@ -76,6 +81,13 @@ const ui = (() => {
 				
 				began = time;
 				duration = length;
+
+				length_min = Math.floor(duration / 1000 / 60);
+				length_sec = Math.floor(duration / 1000) % 60;
+				if (length_sec < 10) {
+					length_sec = "0" + length_sec;
+				}
+				if (html_id["song_length"]) song_length.innerText = `${length_min}:${length_sec}`;
 
 				loop();
 			},
@@ -95,16 +107,24 @@ const ui = (() => {
 	})();
 
 	const beatmap = (() => {
-		var cover = document.getElementById("image");
+		if (html_id["image"])         var cover = document.getElementById("image");
 
-		var title = document.getElementById("title");
-		var subtitle = document.getElementById("subtitle");
-		var artist = document.getElementById("artist");
+		if (html_id["title"])         var title = document.getElementById("title");
+		if (html_id["subtitle"])      var subtitle = document.getElementById("subtitle");
+		if (html_id["artist"])        var artist = document.getElementById("artist");
+		if (html_id["mapper_header"]) var mapper_header = document.getElementById("mapper_header");
+		if (html_id["mapper"])        var mapper = document.getElementById("mapper");
+		if (html_id["mapper_footer"]) var mapper_footer = document.getElementById("mapper_footer");
 
-		var difficulty = document.getElementById("difficulty");
-		var bpm = document.getElementById("bpm");
-		var njs = document.getElementById("njs");
-		var bsr = document.getElementById("bsr");
+		if (html_id["difficulty"])    var difficulty = document.getElementById("difficulty");
+		if (html_id["bpm"])           var bpm = document.getElementById("bpm");
+		if (html_id["njs"])           var njs = document.getElementById("njs");
+		if (html_id["njs_text"])      var njs_text = document.getElementById("njs_text");
+		if (html_id["bsr"])           var bsr = document.getElementById("bsr");
+		if (html_id["bsr_text"])      var bsr_text = document.getElementById("bsr_text");
+		if (html_id["mod"])           var mod = document.getElementById("mod");
+		if (html_id["pre_bsr"])       var pre_bsr = document.getElementById("pre_bsr");
+		if (html_id["pre_bsr_text"])  var pre_bsr_text = document.getElementById("pre_bsr_text");
 		var httpRequest = new XMLHttpRequest();
 		
 		function format(number) {
@@ -119,20 +139,25 @@ const ui = (() => {
 			return number.toString();
 		}
 
-		return (data, time) => {
+		return (data, time, mod_data) => {
 			if (data.difficulty === "ExpertPlus") {
 				data.difficulty = "Expert+";
 			}
 
-			cover.setAttribute("src", `data:image/png;base64,${data.songCover}`);
+			if (html_id["image"])    cover.setAttribute("src", `data:image/png;base64,${data.songCover}`);
 
-			title.innerText = data.songName;
-			subtitle.innerText = data.songSubName;
-			bsr.innerText = '';
+			if (html_id["title"])    title.innerText = data.songName;
+			if (html_id["subtitle"]) subtitle.innerText = data.songSubName;
+			if (html_id["bsr"])      bsr.innerText = '';
+			if (html_id["bsr_text"]) bsr_text.innerText = '';
+			pre_bsr_data = now_bsr;
+			now_bsr = null;
 			
 			httpRequest.onreadystatechange = function() {
 				if(this.readyState == 4 && this.status == 200 && this.response) {
-					bsr.innerText = 'bsr ' + this.response.key;
+					now_bsr = this.response.key;
+					if (html_id["bsr"])      bsr.innerText = this.response.key;
+					if (html_id["bsr_text"]) bsr_text.innerText = bsr_text_org;
 				}
 			}
 			
@@ -143,20 +168,50 @@ const ui = (() => {
 				httpRequest.send(null);
 			}
 			
+			if (html_id["artist"]) artist.innerText = data.songAuthorName;
 			if (data.levelAuthorName) {
-				artist.innerText = `${data.songAuthorName} [${data.levelAuthorName}]`;
+				if (html_id["mapper_header"]) mapper_header.innerText = mapper_header_org;
+				if (html_id["mapper"])        mapper.innerText = data.levelAuthorName;
+				if (html_id["mapper_footer"]) mapper_footer.innerText = mapper_footer_org;
 			} else {
-				artist.innerText = data.songAuthorName;
+				if (html_id["mapper_header"]) mapper_header.innerText = "";
+				if (html_id["mapper"])        mapper.innerText = "";
+				if (html_id["mapper_footer"]) mapper_footer.innerText = "";
 			}
-			
 
-			difficulty.innerText = data.difficulty;
-			bpm.innerText = `${format(data.songBPM)} BPM`;
+			if (html_id["difficulty"]) difficulty.innerText = data.difficulty;
+			if (html_id["bpm"]) bpm.innerText = format(data.songBPM);
 
 			if (data.noteJumpSpeed) {
-				njs.innerText = `${format(data.noteJumpSpeed)} NJS`;
+				if (html_id["njs"]) njs.innerText = format(data.noteJumpSpeed);
+				if (html_id["njs_text"]) njs_text.innerText = njs_text_org;
 			} else {
-				njs.innerText = "";
+				if (html_id["njs"]) njs.innerText = "";
+				if (html_id["njs_text"]) njs_text.innerText = "";
+			}
+			
+			if (html_id["mod"]) {
+				var mod_text = "";
+				if (mod_data.instaFail === true)          mod_text += "IF,";
+				if (mod_data.batteryEnergy === true)      mod_text += "BE,";
+				if (mod_data.disappearingArrows === true) mod_text += "DA,";
+				if (mod_data.ghostNotes === true)         mod_text += "GN,";
+				if (mod_data.songSpeed === "Faster")      mod_text += "FS,";
+				if (mod_data.songSpeed === "Faster")      mod_text += "SS,";
+				if (mod_data.noFail === true)             mod_text += "NF,";
+				if (mod_data.obstacles === false)         mod_text += "NO,";
+				if (mod_data.noBombs === true)            mod_text += "NB,";
+				if (mod_data.noArrows === true)           mod_text += "NA,";
+				mod_text = mod_text.slice(0,-1);
+				mod.innerText = mod_text;
+			}
+			
+			if (pre_bsr_data === null) {
+				if (html_id["pre_bsr"])      pre_bsr.innerText = "";
+				if (html_id["pre_bsr_text"]) pre_bsr_text.innerText = "";
+			} else {
+				if (html_id["pre_bsr"])      pre_bsr.innerText = pre_bsr_data;
+				if (html_id["pre_bsr_text"]) pre_bsr_text.innerText = pre_bsr_text_org;
 			}
 
 			timer.start(Date.now(), data.length);
@@ -165,11 +220,11 @@ const ui = (() => {
 
 	return {
 		hide() {
-			main.classList.add("hidden");
+			if (html_id["overlay"]) main.classList.add("hidden");
 		},
 
 		show() {
-			main.classList.remove("hidden");
+			if (html_id["overlay"]) main.classList.remove("hidden");
 		},
 
 		performance,

--- a/js/ui.js
+++ b/js/ui.js
@@ -12,10 +12,12 @@ const ui = (() => {
 		}
 
 		return (data) => {
-			score.innerText = format(data.score);
-			combo.innerText = data.combo;
-			rank.innerText = data.rank;
-			percentage.innerText = (data.currentMaxScore > 0 ? (Math.floor((data.score / data.currentMaxScore) * 1000) / 10) : 0) + "%";
+			if (performance_display) {
+				score.innerText = format(data.score);
+				combo.innerText = data.combo;
+				rank.innerText = data.rank;
+				percentage.innerText = (data.currentMaxScore > 0 ? (Math.floor((data.score / data.currentMaxScore) * 1000) / 10) : 0) + "%";
+			}
 		}
 	})();
 
@@ -102,6 +104,8 @@ const ui = (() => {
 		var difficulty = document.getElementById("difficulty");
 		var bpm = document.getElementById("bpm");
 		var njs = document.getElementById("njs");
+		var bsr = document.getElementById("bsr");
+		var httpRequest = new XMLHttpRequest();
 		
 		function format(number) {
 			if (Number.isNaN(number)) {
@@ -124,6 +128,20 @@ const ui = (() => {
 
 			title.innerText = data.songName;
 			subtitle.innerText = data.songSubName;
+			bsr.innerText = '';
+			
+			httpRequest.onreadystatechange = function() {
+				if(this.readyState == 4 && this.status == 200 && this.response) {
+					bsr.innerText = 'bsr ' + this.response.key;
+				}
+			}
+			
+			if (bsr_display && data.songHash != null && data.songHash.match(/^[0-9A-F]{40}/i)) {
+				httpRequest.open('GET', 'https://beatsaver.com/api/maps/by-hash/' + data.songHash.substr(0, 40), true);
+				httpRequest.timeout = 5000;
+				httpRequest.responseType = 'json';
+				httpRequest.send(null);
+			}
 			
 			if (data.levelAuthorName) {
 				artist.innerText = `${data.songAuthorName} [${data.levelAuthorName}]`;

--- a/rtl2.css
+++ b/rtl2.css
@@ -1,0 +1,17 @@
+#overlay {
+	direction: ltr;
+	right: 40px;
+    text-align: right;
+}
+
+#titles {
+	display: block;
+}
+
+#njs {
+	direction: rtl;
+}
+
+#score {
+	transform: translate(2px, 0);
+}

--- a/simple.html
+++ b/simple.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Overlay</title>
+		<link rel="stylesheet" href="style.css">
+		<link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700,800" rel="stylesheet"> 
+	</head>
+	
+	<body>
+		<div id="overlay" class="hidden">
+			<div id="performance">
+				<div class="performance-group">
+					<span class="text" id="percentage">0%</span>
+					<span class="text" id="score" style="display:inline-block;font-size:18px;font-weight:600;">0</span>
+				</div>
+				<div>
+					<span id="title" style="display:inline-block;font-size: 22px;font-weight: 600;">Title</span>
+					<div id="bsr-group" style="display:inline-block;font-size: 15px;font-weight: 600;">
+						<span id="bsr_text"> bsr: </span><span id="bsr" style="font-size:15px;font-weight:600;">00000</span>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<script src="./js/options.js"></script>
+		
+		<script src="./js/ui.js"></script>
+		<script src="./js/events.js"></script>
+		<script src="./js/manager.js"></script>
+	</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -83,6 +83,15 @@ body {
 	letter-spacing: 3px;
 }
 
+#bsr {
+	display: inline-block;
+
+	font-size: 18px;
+	font-weight: 800;
+	letter-spacing: 3px;
+	margin: 0 0px;
+}
+
 #difficulty {
 	padding: 4px 5px 4px 8px;
 

--- a/style.css
+++ b/style.css
@@ -67,14 +67,14 @@ body {
 	margin: 0 4px 2px 4px;
 }
 
-#artist {
+#artist-group {
 	display: block;
 	font-size: 16px;
 	font-weight: 400;
 	margin: 2px 0 0 0;
 }
 
-#difficulty, #bpm, #njs {
+#difficulty, #bpm-group, #njs-group {
 	display: inline-block;
 
 	font-size: 10px;
@@ -83,7 +83,7 @@ body {
 	letter-spacing: 3px;
 }
 
-#bsr {
+#bsr-group {
 	display: inline-block;
 
 	font-size: 18px;
@@ -100,11 +100,11 @@ body {
 	border-radius: 4px;
 }
 
-#bpm {
+#bpm-group {
 	margin: 0 8px;
 }
 
-#njs {
+#njs-group {
 	margin: 0 0px;
 }
 


### PR DESCRIPTION
In the recently released  [beatsaber-http-status](https://github.com/opl-/beatsaber-http-status/releases) v1.11.0, a fix was made for beatmap.songHash has been fixed correctly.
Added the ability to use this songHash to find and display map keys (bsr) from beatsaver.
This is indicated by the modifiers option 'bsr' and not by default.

Also, since we have a performance display in the Counter+ mod, the You may only want the beatmap display.
Add 'no-performance' to the options to make the performance display I made it possible to turn it off.

![image](https://rynan4818.github.io/beatsaber-overlay-bsr-image.png)


I'm using a translation tool because I'm not very good at English.
Please note that there are some oddities in the text.

